### PR TITLE
check for windows before importing toast

### DIFF
--- a/screenshot.py
+++ b/screenshot.py
@@ -10,7 +10,7 @@ import pytesseract
 from io import BytesIO
 import pyperclip
 from PyQt5.QtCore import QSettings
-from toast import show_clipboard_notification_windows, show_notification_windows
+if os.name == "nt": from toast import show_clipboard_notification_windows, show_notification_windows
 
 
 pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"  # Correct path
@@ -126,8 +126,8 @@ def process_ocr(cropped_image=None, save_path="extracted_text.txt"):
                 if os.name == "nt":  # Windows
                     os.startfile(save_path)
                 elif os.name == "posix":  # macOS/Linux
-                    os.system(f"xdg-open {text_file}")  # Linux
-                    os.system(f"open {text_file}")  # macOS
+                    os.system(f"xdg-open {save_path}")  # Linux
+                    os.system(f"open {save_path}")  # macOS
             else:
                 print("No text extracted from the image.")
         else:

--- a/screenshot.py
+++ b/screenshot.py
@@ -10,10 +10,13 @@ import pytesseract
 from io import BytesIO
 import pyperclip
 from PyQt5.QtCore import QSettings
-if os.name == "nt": from toast import show_clipboard_notification_windows, show_notification_windows
 
+if os.name == "nt": 
+    from toast import show_clipboard_notification_windows, show_notification_windows
+    pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"  # Correct path
+else :
+    pytesseract.pytesseract.tesseract_cmd = "/usr/bin/tesseract"
 
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"  # Correct path
 
  
 """


### PR DESCRIPTION
tested on Ubuntu. UI loads and screenshot works. If OCR worked on linux before toast, it should work now.

I would assume there is something else missing, since console outputs:
`Error processing OCR: C:\Program Files\Tesseract-OCR\tesseract.exe is not installed or it's not in your PATH. See README file for more information.`
which I would assume is the program looking for a Windows install of Tesseract-OCR.