### PR TITLE
Issue #57 Changes

### DIFF
--- a/UI.py
+++ b/UI.py
@@ -162,8 +162,15 @@ class UI(QWidget):
                 # calling the process ocr to take the screen and save it
                 # you can also pass a custom path to the process_ocr to save it in a custom location  
                 #converts to texts and saves
-                
-            os.startfile(self.file_path) 
+            settings = QSettings("Software Engineering Class", "Snapshot")
+            open_notepad_settings = settings.value("File Settings: ", "Open Destination File")
+            if open_notepad_settings == "Open Destination File":
+                # Open the text file automatically
+                if os.name == "nt":  # Windows
+                    os.startfile(self.file_path)
+                elif os.name == "posix":  # macOS/Linux
+                    os.system(f"xdg-open {self.file_path}")  # Linux
+                    os.system(f"open {self.file_path}")  # macOS
         else:
             self.image_label.setText("Error loading chosen file")
 
@@ -187,7 +194,15 @@ class UI(QWidget):
                   
             # Convert PIL Image to QPixmap      
             self.convert_to_QPixmap (cropped_image)
-            os.startfile(self.file_path)
+            settings = QSettings("Software Engineering Class", "Snapshot")
+            open_notepad_settings = settings.value("File Settings: ", "Open Destination File")
+            if open_notepad_settings == "Open Destination File":
+                # Open the text file automatically
+                if os.name == "nt":  # Windows
+                    os.startfile(self.file_path)
+                elif os.name == "posix":  # macOS/Linux
+                    os.system(f"xdg-open {self.file_path}")  # Linux
+                    os.system(f"open {self.file_path}")  # macOS
 
         else:
 

--- a/screenshot.py
+++ b/screenshot.py
@@ -135,13 +135,14 @@ def process_ocr(cropped_image=None, save_path="extracted_text.txt"):
                     else:
                         show_clipboard_notification_windows(cropped_image, extracted_text)
 
-
-                # Open the text file automatically
-                if os.name == "nt":  # Windows
-                    os.startfile(save_path)
-                elif os.name == "posix":  # macOS/Linux
-                    os.system(f"xdg-open {save_path}")  # Linux
-                    os.system(f"open {save_path}")  # macOS
+                open_notepad_settings = settings.value("File Settings: ", "Open Destination File")
+                if open_notepad_settings == "Open Destination File":
+                    # Open the text file automatically
+                    if os.name == "nt":  # Windows
+                        os.startfile(save_path)
+                    elif os.name == "posix":  # macOS/Linux
+                        os.system(f"xdg-open {save_path}")  # Linux
+                        os.system(f"open {save_path}")  # macOS
             else:
                 print("No text extracted from the image.")
 

--- a/toast.py
+++ b/toast.py
@@ -1,9 +1,11 @@
 import os
+import threading
 from win11toast import toast
 from PIL import Image, ImageTk
 import pyperclip
 
 def show_clipboard_notification_windows(cropped_image, extracted_text):
+    def notify():
         """Shows a toast notification with an option to open the text editor."""
         def handle_click(event):
             action = event.get('arguments', 'http:')[5:] #ignore 'http:' prefix; workaround for win11toast
@@ -23,8 +25,10 @@ def show_clipboard_notification_windows(cropped_image, extracted_text):
         ]
 
         toast('Text copied to clipboard', extracted_text, on_click=handle_click, buttons=buttons)
+    threading.Thread(target=notify, daemon=True).start()
 
 def show_notification_windows(cropped_image, extracted_text):
+    def notify():
         """Shows a toast notification with an option to open the text editor."""
         def handle_click(event):
             action = event.get('arguments', 'http:')[5:] #ignore 'http:' prefix; workaround for win11toast
@@ -48,3 +52,4 @@ def show_notification_windows(cropped_image, extracted_text):
         ]
 
         toast('Text copied to clipboard', extracted_text, on_click=handle_click, buttons=buttons)
+    threading.Thread(target=notify, daemon=True).start()

--- a/toast.py
+++ b/toast.py
@@ -24,7 +24,7 @@ def show_clipboard_notification_windows(cropped_image, extracted_text):
             {'activationType': 'protocol', 'arguments': 'http:2', 'content': 'View Image'}
         ]
 
-        toast('Text copied to clipboard', extracted_text, on_click=handle_click, buttons=buttons)
+        toast('Text extracted from image', extracted_text, on_click=handle_click, buttons=buttons)
     threading.Thread(target=notify, daemon=True).start()
 
 def show_notification_windows(cropped_image, extracted_text):


### PR DESCRIPTION
+ added threading to toast functions.
   * The program should no longer hang waiting for notifications to be interacted with, dismissed, or timed out.
+ added settings and OS checks to all unprompted instances of `os.startfile()`
   * Text editor should now only open when prompted via notification dialogue and/or automatically when the relevant setting active.
   * This should also fix any errors relating to `os.startfile()` on Linux
+ modified notification header text
   * Notifications should no longer state that text was copied to clipboard when the relevant setting is toggled off